### PR TITLE
ci(security): update OSV Scanner to 2.5.0

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # google/osv-scanner-action image v2.5.0 (linux/amd64), resolved 2026-08-09.
+  # google/osv-scanner-action image v2.5.0 (linux/amd64), resolved 2026-08-08.
   # Pin the runtime image itself: the upstream action metadata references a
   # mutable version tag even when the action is pinned to a commit SHA.
   OSV_SCANNER_IMAGE: "ghcr.io/google/osv-scanner-action@sha256:4cc9d6b5a6bb3a81c38c8d1610f6855512ddd1ba5af77083a856f171dbd0d463"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -29,10 +29,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # google/osv-scanner-action image v2.4.0 (linux/amd64), resolved 2026-07-29.
+  # google/osv-scanner-action image v2.5.0 (linux/amd64), resolved 2026-08-09.
   # Pin the runtime image itself: the upstream action metadata references a
   # mutable version tag even when the action is pinned to a commit SHA.
-  OSV_SCANNER_IMAGE: "ghcr.io/google/osv-scanner-action@sha256:2b2b9fbe57b14097fb6953577f2fbecf49941e2346c4eceb9f0852a9682ae868"
+  OSV_SCANNER_IMAGE: "ghcr.io/google/osv-scanner-action@sha256:4cc9d6b5a6bb3a81c38c8d1610f6855512ddd1ba5af77083a856f171dbd0d463"
 
 jobs:
   pinned-tools:

--- a/scripts/ci/check-pinned-tools.sh
+++ b/scripts/ci/check-pinned-tools.sh
@@ -44,6 +44,34 @@ check_release() {
     "$name" "$current" "$cooling_hours"
 }
 
+check_osv_image_digest() {
+  local version="$1"
+  local image token expected_digest actual_digest
+
+  image="$(sed -nE 's/.*OSV_SCANNER_IMAGE: "([^"]+)".*/\1/p' .github/workflows/security.yaml)"
+  expected_digest="${image##*@}"
+  if [[ -z "$image" || "$expected_digest" == "$image" ]]; then
+    printf '::error title=osv-scanner digest missing::OSV_SCANNER_IMAGE must use an immutable digest.\n'
+    return 1
+  fi
+
+  token="$(curl --fail --silent --show-error \
+    "https://ghcr.io/token?scope=repository:google/osv-scanner-action:pull" | jq -er '.token')"
+  actual_digest="$(curl --fail --silent --show-error --dump-header - --output /dev/null \
+    --header "Authorization: Bearer $token" \
+    --header 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+    "https://ghcr.io/v2/google/osv-scanner-action/manifests/v$version" \
+    | awk 'tolower($1) == "docker-content-digest:" { gsub("\\r", "", $2); print $2 }')"
+
+  if [[ -z "$actual_digest" || "$expected_digest" != "$actual_digest" ]]; then
+    printf '::error title=osv-scanner digest mismatch::Pinned digest %s; v%s resolves to %s.\n' \
+      "$expected_digest" "$version" "${actual_digest:-unknown}"
+    return 1
+  fi
+
+  printf '✓ osv-scanner v%s runtime digest matches GHCR.\n' "$version"
+}
+
 nose_version="$(sed -nE 's/^nose_version="([^"]+)"/\1/p' scripts/ci/install-nose.sh)"
 osv_version="$(sed -nE 's/.*osv-scanner-action image v([^ ]+).*/\1/p' .github/workflows/security.yaml)"
 semgrep_version="$(sed -nE 's/.*semgrep\/semgrep:([^ @]+).*/\1/p' .github/workflows/security.yaml | head -n 1)"
@@ -51,5 +79,6 @@ semgrep_version="$(sed -nE 's/.*semgrep\/semgrep:([^ @]+).*/\1/p' .github/workfl
 status=0
 check_release nose "$nose_version" corca-ai/nose || status=1
 check_release osv-scanner "$osv_version" google/osv-scanner || status=1
+check_osv_image_digest "$osv_version" || status=1
 check_release semgrep "$semgrep_version" semgrep/semgrep || status=1
 exit "$status"


### PR DESCRIPTION
## Summary
- update the pinned OSV Scanner runtime image from 2.4.0 to 2.5.0
- retain an immutable linux/amd64 GHCR digest
- restore the pinned-tool freshness security gate

## Validation
- `scripts/ci/check-pinned-tools.sh`
- `actionlint v1.7.12 .github/workflows/*.yaml`
- all required GitHub Actions checks passed